### PR TITLE
Stern SAM LED support, JIT compiler, and improved timings

### DIFF
--- a/src/cpu/arm7/arm7core.c
+++ b/src/cpu/arm7/arm7core.c
@@ -313,7 +313,7 @@ INLINE void SwitchMode (int cpsr_mode_val)
    ROR >32   = Same result as ROR n-32 until amount in range of 1-32 then follow rules
 */
 
-static data32_t decodeShift( data32_t insn, data32_t *pCarry)
+static inline data32_t decodeShift( data32_t insn, data32_t *pCarry)
 {
 	data32_t k	= (insn & INSN_OP2_SHIFT) >> INSN_OP2_SHIFT_SHIFT;	//Bits 11-7
 	data32_t rm	= GET_REGISTER( insn & INSN_OP2_RM );

--- a/src/cpu/arm7/arm7core.c
+++ b/src/cpu/arm7/arm7core.c
@@ -727,7 +727,7 @@ static void arm7_check_irq_state(void)
 
 	//FIRQ
 	if (ARM7.pendingFiq && (cpsr & F_MASK)==0) {
-		ARM7.pendingFiq = 0;
+		//ARM7.pendingFiq = 0;
 		SwitchMode(eARM7_MODE_FIQ);				/* Set FIQ mode so PC is saved to correct R14 bank */
 		SET_REGISTER( 14, pc - 4 + 4);			/* save PC to R14 */
 		SET_REGISTER( SPSR, cpsr );				/* Save current CPSR */
@@ -739,7 +739,7 @@ static void arm7_check_irq_state(void)
 
 	//IRQ
 	if (ARM7.pendingIrq && (cpsr & I_MASK)==0) {
-		ARM7.pendingIrq = 0;
+		//ARM7.pendingIrq = 0;
 		SwitchMode(eARM7_MODE_IRQ);				/* Set IRQ mode so PC is saved to correct R14 bank */
 		SET_REGISTER( 14, pc - 4 + 4);			/* save PC to R14 */
 		SET_REGISTER( SPSR, cpsr );				/* Save current CPSR */
@@ -806,11 +806,11 @@ static void arm7_core_set_irq_line(int irqline, int state)
 	switch (irqline) {
 
 	case ARM7_IRQ_LINE: /* IRQ */
-		ARM7.pendingIrq |= (state & 1);
+		ARM7.pendingIrq = (state & 1);
 		break;
 
 	case ARM7_FIRQ_LINE: /* FIRQ */
-		ARM7.pendingFiq |= (state & 1);
+		ARM7.pendingFiq = (state & 1);
 		break;
 
 	case ARM7_ABORT_EXCEPTION:
@@ -830,8 +830,7 @@ static void arm7_core_set_irq_line(int irqline, int state)
 	// This function is likely to be called by downstream hardware simulations, possibly in the middle of a 
 	// READ or WRITE request.  What we can do though is ensure MAME will check soon.   
 
-	ARM7_ICOUNT = 0;
-	//ARM7_CHECKIRQ;
+	ARM7_CHECKIRQ;
 }
 
 /***************************************************************************

--- a/src/cpu/arm7/arm7exec.c
+++ b/src/cpu/arm7/arm7exec.c
@@ -45,6 +45,7 @@ extern unsigned at91_get_reg(int regnum);
 .. though there's still room for improvement. */
 {
 	data32_t pc;
+	static data32_t pc_prev2 = 0, pc_prev1=0;
 	data32_t insn;
 
 	RESET_ICOUNT
@@ -64,16 +65,21 @@ extern unsigned at91_get_reg(int regnum);
 
 			// Debug test triggers
 
-			//if (pc == 0x9c60)
-			//	pc = 0x9c60;
+			if (pc == 0x25b5c)
+			{
+				//debug_key_pressed=1;
+				pc = 0x25b5c;
+			}
 
 			// Helpful to backtrace a crash :)
 		
-			//pc_prev2 = pc_prev1;
-			//pc_prev1 = pc;
+			
 		
 		JIT_FETCH(ARM7.jit, pc);
-		insn = cpu_readop32(pc);
+ 		insn = cpu_readop32(pc);
+
+		pc_prev2 = pc_prev1;
+		pc_prev1 = pc;
 
 		/* process condition codes for this instruction */
 		switch (insn >> INSN_COND_SHIFT)

--- a/src/cpu/arm7/arm7exec.c
+++ b/src/cpu/arm7/arm7exec.c
@@ -38,6 +38,7 @@
  *
 *****************************************************************************/
 
+
 extern unsigned at91_get_reg(int regnum);
 
 /* This implementation uses an improved switch() for hopefully faster opcode fetches compared to my last version
@@ -60,6 +61,17 @@ extern unsigned at91_get_reg(int regnum);
 
 		/* load 32 bit instruction, trying the JIT first */
 		pc = R15;
+
+			// Debug test triggers
+
+			//if (pc == 0x9c60)
+			//	pc = 0x9c60;
+
+			// Helpful to backtrace a crash :)
+		
+			//pc_prev2 = pc_prev1;
+			//pc_prev1 = pc;
+		
 		JIT_FETCH(ARM7.jit, pc);
 		insn = cpu_readop32(pc);
 
@@ -221,6 +233,7 @@ extern unsigned at91_get_reg(int regnum);
 			case 7:
 				HandleMemSingle(insn);
 				R15 += 4;
+				ARM7_CHECKIRQ;
 				break;
 			/* Block Data Transfer/Access */
 			case 8:
@@ -256,12 +269,13 @@ extern unsigned at91_get_reg(int regnum);
 			/* Undefined */
 			default:
 				ARM7.pendingSwi = 1;
-				ARM7_CHECKIRQ;
+				
 				ARM7_ICOUNT -= 1;				//undefined takes 4 cycles (page 77)
 				LOG(("%08x:  Undefined instruction\n",pc-4));
 				L_Next:
 					R15 += 4;
 					ARM7_ICOUNT +=2;	//Any unexecuted instruction only takes 1 cycle (page 193)
+					ARM7_CHECKIRQ;
 		}
 		/* All instructions remove 3 cycles.. Others taking less / more will have adjusted this # prior to here */
 		ARM7_ICOUNT -= 3;
@@ -344,6 +358,7 @@ jit_go_native:
 		ARM7_ICOUNT = tmp2;
 	}
 	
+	ARM7_CHECKIRQ;
 	// resume emulation
 	goto resume_from_jit;
 

--- a/src/cpu/arm7/arm7jit.c
+++ b/src/cpu/arm7/arm7jit.c
@@ -262,10 +262,11 @@ static int MUL32(struct jit_ctl *jit, data32_t addr, data32_t insn, int *cycles)
 	// if the S flag is set, set the N and Z flags
 	if (insn & INSN_S)
 	{
+		// Bugfixes here -- djrobx 
 		// figure Z from the result
-		emit(CMP, EAX, 0);
+		emit(CMP, EAX, Imm, 0);
 		emit(SETZ, BL);          // EBX = xxxxxxxx xxxxxxxx xxxxxxxx 0000000Z
-		emit(SHL, BL, 7);        // EBX = xxxxxxxx xxxxxxxx xxxxxxxx Z0000000
+		emit(SHL, BL, Imm, 7);        // EBX = xxxxxxxx xxxxxxxx xxxxxxxx Z0000000
 
 		// figure N from the result
 		emit(TEST, EAX, Imm, 0x80000000);
@@ -275,7 +276,7 @@ static int MUL32(struct jit_ctl *jit, data32_t addr, data32_t insn, int *cycles)
 		// MUL always sets C to 0 and leaves V unchanged - we conveniently have
 		// 0 in the right bit for C at this point.  Mask out the bits in CPSR
 		// and OR in the new flags from EBX.
-		emit(AND, DwordPtr, RCPSR, 0x1FFFFFFF);
+		emit(AND, DwordPtr, RCPSR, Imm, 0x1FFFFFFF);
 		emit(OR, RCPSR, EBX);
 	}
 
@@ -425,11 +426,12 @@ static void gen_mem(struct jit_ctl *jit, int rd, int ld, int siz, int sx, int ad
 				emit(MOV, Rn(rd+1), EAX);
 				emit(POP, EAX);
 			}
-			else if (siz == 32)
+		/*	else if (siz == 32)
 			{
 				// 32-bit operand
-				emit(MOV, Rn(rd), EAX);
-			}
+				// Nothing to do, this was being generated twice.
+				// emit(MOV, Rn(rd), EAX);
+			}*/
 			else if (siz == 16)
 			{
 				// 16 bits - sign-extend or zero-extend AX to EAX 
@@ -438,7 +440,7 @@ static void gen_mem(struct jit_ctl *jit, int rd, int ld, int siz, int sx, int ad
 				else
 					emit(MOVZX, EAX, AX);
 			}
-			else
+			else if (siz ==8)
 			{
 				// 8 bits - sign-extend or zero-extend AL to EAX 
 				if (sx)
@@ -911,11 +913,17 @@ static void spsr_to_cpsr(void)
 	{
 		// load CPSR from SPSR
 		SET_CPSR(GET_REGISTER(SPSR));
-
 		// do the mode switch
 		SwitchMode(GET_MODE);
+		ARM7_CHECKIRQ;
 	}
 }
+
+static void check_irq_helper(void)
+{
+	ARM7_CHECKIRQ;
+}
+
 
 // Emit code for a jump to an emulator address.  We normally generate the cycle count
 // update at the end of an instruction's generated code, but we have to generate it
@@ -957,6 +965,10 @@ static int ALU(struct jit_ctl *jit, data32_t addr, data32_t insn, int *is_br, in
 	int is_sub_op;
 	int is_test_op;
 	int need_shift_carry_out;
+//  TODO: BUGGY MOV opcode on Mtl_145h
+//	if (addr == 0x14568)
+//		addr = 0x14568;
+
 
 	// Normal data processing is 1 cycle - reduce the default 3-cycle count by 2
 	*cycles -= 2;
@@ -1153,6 +1165,8 @@ static int ALU(struct jit_ctl *jit, data32_t addr, data32_t insn, int *is_br, in
 	case OPCODE_MOV:
 		// MOV - moves op2
 		result_reg = EAX;
+		// BUGGY OPCODE
+		return 0;
 		break;
 
 	case OPCODE_MVN:
@@ -1343,7 +1357,7 @@ static int LDR_STR(struct jit_ctl *jit, data32_t addr, data32_t insn, int *is_br
 			gen_mem(jit, rd, ld, byt ? 8 : 32, 0, addr, is_br, EBX, 0, 0);
 			return 1;
 		}
-		else if (oty == 0 && (insn & 0xfff) == 0)
+		else if (oty == 0) //&& (insn & 0xfff) == 0)
 		{
 			// writing back a (possibly) changed value - save the index register
 			// for the write-back
@@ -1721,6 +1735,8 @@ static int LDM_STM(struct jit_ctl *jit, data32_t addr, data32_t insn, int *is_br
 	// check for loading R15
 	if (ld && (insn & 0x8000))
 	{
+		return 0;
+
 		// loading R15 costs 2 extra cycles
 		*cycles += 2;
 
@@ -1902,6 +1918,12 @@ static int xlat(struct jit_ctl *jit, data32_t pc)
 		// presume this instruction won't perform a branch
 		int br = 0;
 
+		/* Debugging trap
+		if (addr == 0x12790)
+		{ 
+			addr = 0x12790;
+		}*/
+		
 		// if we've strayed outside the JIT-able range, stop here
 		if (addr < jit->minAddr || addr >= jit->maxAddr)
 		{

--- a/src/cpu/at91/at91.c
+++ b/src/cpu/at91/at91.c
@@ -58,11 +58,6 @@ extern int activecpu;
 #define LOG_AT91 0					//Turn on/off logging of all AT91 debugging info
 #define LOG_TOSCREEN 0				//Send Log data to screen, otherwise will go to log file
 
-#if (defined(_DEBUG) && defined(LOG_TOSCREEN))
-// For console debug window output
-#include<Windows.h>
-#endif
-
 //Flags for specific Logging
 #define LOG_TIMERS 0				//Turn on/off logging of Timer Info
 #define LOG_TIMER_STAT_READ 0		//Turn on/off logging of Timer Status Read
@@ -77,7 +72,12 @@ extern int activecpu;
 #define LOG_AIC_IVW 0				//Turn on/off logging of AIC - Interrupt Vector Write Command
 #define LOG_AIC_EOI 0				//Turn on/off logging of AIC - End of Interrupt Command
 #define LOG_AIC_VECTOR_READ 0		//Turn on/off logging of AIC - Vector Address Read
-#define LOG_USART1_DATA_OUT 0
+#define LOG_USART1_DATA_OUT 1
+
+#if (defined(_DEBUG) && (defined(LOG_TOSCREEN) || defined(LOG_USART1_DATA_OUT)))
+// For console debug window output
+#include<Windows.h>
+#endif
 
 //Flags for Testing
 #define INT_BLOCK_FIQ   0			//Turn on/off blocking of specified Interrupt (Leave OFF for non-test situation)
@@ -95,11 +95,16 @@ INLINE data16_t at91_cpu_read16( int addr );
 INLINE data8_t at91_cpu_read8( int addr );
 void at91_fire_irq(int irqline);
 void (*at91_transmit_serial)(int usartno, data8_t *data, int size) = NULL;
-void sam_serial_hack();
+void (*at91_serial_receive_ready)(int usartno) = NULL;
 
 void at91_set_transmit_serial(void (*fp)(int usartno, data8_t *data, int size))
 {
 	at91_transmit_serial = fp;
+}
+
+void at91_set_serial_receive_ready(void (*fp)(int usartno))
+{
+	at91_serial_receive_ready = fp;
 }
 
 #if !USE_MAME_TIMERS
@@ -200,6 +205,7 @@ typedef struct
 typedef struct
 {
 	int cpu_freq;								//CPU Clock Frequency (as specified by the Machine Driver)
+	int cpunum;									//CPU num
 	data32_t *page0_ram_ptr;					//holder for the pointer set by the driver to ram @ page 0.
 	data32_t *reset_ram_ptr;					//holder for the pointer set by the driver to ram swap location.
 	data32_t page0[0x100000];					//Hold copy of original boot rom data @ page 0.
@@ -212,6 +218,8 @@ static AT91_REGS at91;
 static AT91_REGS_RS at91rs;
 int at91_ICount;
 int at91_priority_map[31];
+int at91_irqstack[31];
+int at91_irqstackpos = 0;
 
 #define AT91_RECEIVE_BUFFER_SIZE 512
 
@@ -252,9 +260,8 @@ static AT91_REGS_USART at91usart[2] = {{ 0, US_TXRDY | US_TXEMPTY | US_ENDTX,0,0
 #undef LOG
 
 #if LOG_AT91
-#if LOG_TOSCREEN
 
-#ifdef _DEBUG
+#if LOG_TOSCREEN
 
 void DebuggerLog ( const char * format, ... )
 {
@@ -278,9 +285,6 @@ void DebuggerLog ( const char * format, ... )
 
 #endif
 
-#else
-#define LOG(x) logerror x
-#endif
 #else
 #define LOG(x)
 #endif
@@ -434,6 +438,11 @@ mame_timer* at91_serial_timer=NULL;
 
 static void serial_timer_event(int timer_num);
 
+void at91_irqcheck()
+{
+	arm7_check_irq_state();
+}
+
 void at91_pending_serial(int usartno)
 {
 	// We can't process serial output immediately, the code will get confused and loop.
@@ -459,7 +468,8 @@ static void serial_timer_event(int timer_num)
 			{
 				wchar_t tmp1[20];
 
-				OutputDebugStringW(L"DO: ");
+				swprintf(tmp1, _countof(tmp1), L"DO%d: ", usartno);
+				OutputDebugStringW(tmp1);
 
 				for (i = 0; i < at91usart[usartno].US_TCR; i++)
 				{
@@ -503,7 +513,9 @@ static void serial_timer_event(int timer_num)
 
 				if ((data8_t)at91usart[usartno].US_THR == 0x80)
 					OutputDebugStringW(L"\n");
-				swprintf(tmp1, _countof(tmp1), L"%02X", (data8_t)at91usart[usartno].US_THR);
+				swprintf(tmp1, _countof(tmp1), L"%c", (data8_t)at91usart[usartno].US_THR);
+
+				//				swprintf(tmp1, _countof(tmp1), L"%02X", (data8_t)at91usart[usartno].US_THR);
 				OutputDebugStringW(tmp1);
 #endif			
 				if (at91_transmit_serial)
@@ -518,7 +530,28 @@ static void serial_timer_event(int timer_num)
 				{
 					at91_fire_irq(AT91_USART_IRQ(usartno));
 				} 
+			} 
+		if (at91usart[usartno].at91_rbuf_tail != at91usart[usartno].at91_rbuf_head)
+		{
+			if (at91usart[usartno].US_RPR !=0 && at91usart[usartno].US_RCR > 0 )
+			{
+				int i;
+				for (i=0;i<0x40;i++ && at91usart[usartno].US_RCR > 0)
+				{
+					cpu_writemem32ledw(at91usart[usartno].US_RPR++, 0x29);
+					at91usart[usartno].US_RPR++;
+					at91usart[usartno].US_RCR--;
+
+				}
+				//at91usart[usartno].US_RPR += 5;
+				//at91usart[usartno].US_RCR -= 5;
+/*				cpu_writemem32ledw(at91usart[usartno].US_RPR++, at91usart[usartno].at91_receivebuf[at91usart[usartno].at91_rbuf_tail]);
+				if (at91usart[usartno].at91_rbuf_tail == AT91_RECEIVE_BUFFER_SIZE-1)
+					at91usart[usartno].at91_rbuf_tail = 0;
+				at91usart[usartno].US_RCR--; */
+				at91usart[usartno].US_CSR |= US_ENDRX;
 			}
+		}
 	}
 }
 
@@ -560,23 +593,8 @@ void at91_usart_read(int usartno, int addr, data32_t *pData)
 	switch ((addr & 0xff) / 4)
 	{
 	case 0x0c: // Receive pointer
-		if (usartno == 0)
-		{
-			static int hasrunhack =0;
-
-			if (!hasrunhack)
-			{
-				hasrunhack=1;
-				*pData = at91usart[usartno].US_RPR;
-				/* HACK ALERT - Not even going to bother doing this cleanly.  See funciton in sam.c for explanation. */
-				sam_serial_hack();
-				// Fire IRQ.
-				//this hack below gets some implementations to set up a receive buffer.
-				//at91usart[usartno].US_CSR |= US_ENDRX;
-				//at91.aic_irqstatus = AT91_USART_IRQ(usartno);
-				//at91_receive_serial(1,(data8_t *)"zc ver\r", 7);
-			}
-		}
+		if (at91_serial_receive_ready)
+			at91_serial_receive_ready(usartno);
 		*pData = at91usart[usartno].US_RPR;
 		break;
 	case 0x0d:  // Receive counter:
@@ -1207,15 +1225,26 @@ INLINE void internal_write (int addr, data32_t data)
 				case 0x124:
 					CLEAR_BITS(at91.aic_irqmask,data);
 					break;
+				// AIC Interrupt Clear
+				case 0x128:
+					CLEAR_BITS(at91.aic_irqpending,data);
+					break;
+				case 0x12C:
+					SET_BITS(at91.aic_irqpending,data);
+					break;
 
 				//End of Interrupt
 				case 0x130:
 					logit = LOG_AIC_EOI;
-					at91.aic_irqstatus = 0;
-					if (at91.aic_irqpending > 1)
+					at91.aic_irqstatus = at91_irqstack[--at91_irqstackpos];
+					if (at91_irqstackpos < 0)
 					{
-						arm7_core_set_irq_line(ARM7_IRQ_LINE, 1);
-						//arm7_core_set_irq_line(ARM7_IRQ_LINE, 0);
+						// should never happen if ROM code is working.
+						at91_irqstackpos = 0;
+					}
+					if (at91.aic_irqpending > 1 && at91.aic_irqstatus == 0)
+					{
+						ARM7.pendingIrq = 1;
 					}
 					break;
 				case 0x134:
@@ -1427,6 +1456,12 @@ INLINE data32_t internal_read (int addr)
 					{
 						if (at91.aic_irqpending & (1 << at91_priority_map[i]))
 						{
+							at91_irqstack[at91_irqstackpos++] = at91.aic_irqstatus;
+							if (at91_irqstackpos >= 32)
+							{
+								// something's wrong if we get here.
+								at91_irqstackpos = 31;
+							}
 							at91.aic_irqstatus = at91_priority_map[i];
 							data = at91.aic_vectors[at91_priority_map[i]];
 							at91.aic_irqpending &= ~(1 << at91_priority_map[i]);
@@ -1435,12 +1470,15 @@ INLINE data32_t internal_read (int addr)
 					}
 					if (i==31) 
 						data = at91.aic_spurious;
+     				ARM7.pendingIrq = 0;
+//					arm7_core_set_irq_line(ARM7_IRQ_LINE, 0);
 					break;
 
 				//FIQ - Has it's own register address
 				case 0x104:
 					logit = LOG_AIC_VECTOR_READ;
 					data = at91.aic_vectors[0];
+					ARM7.pendingFiq = 0;
 					break;
 
 				//Interrupt Status
@@ -1759,20 +1797,34 @@ void at91_fire_irq(int irqline)
 	}
 
 	if(irqline == AT91_FIQ_IRQ)
-		irqline = ARM7_FIRQ_LINE;		//if it's our FIQ, make it ARM7 FIRQ
+	{
+		cpu_set_irq_line(at91rs.cpunum, ARM7_FIRQ_LINE, PULSE_LINE);
+	}
 	else
 	{
 		at91.aic_irqpending |= (1 << irqline);
-		irqline = ARM7_IRQ_LINE;		//Anything else is an ARM7 IRQ.
-	}
+		if (at91.aic_irqstatus > 0)
+		{
+			// We only want to assert if this IRQ is higher in priority than what's currently being processed.
+			int i;
 
-	arm7_core_set_irq_line(irqline, 1);
-//	arm7_core_set_irq_line(irqline, 0);  // Doesn't seem to be needed?
+			for (i = 0; i < 31; i++)
+			{
+						if (at91_priority_map[i] == at91.aic_irqstatus)
+							break;
+						if (at91_priority_map[i] == irqline)
+						{
+							ARM7.pendingIrq = 1;
+							break;
+						}
+			}
+		} else
+			ARM7.pendingIrq = 1;
+	}
 }
 
 void at91_set_irq_line(int irqline, int state)
 {
-	
 	arm7_core_set_irq_line(irqline,state);
 }
 
@@ -1922,25 +1974,28 @@ void at91_init(void)
 
 	//Store the cpu clock frequency (is there any easier way to get this?)
 	at91rs.cpu_freq = Machine->drv->cpu[activecpu].cpu_clock;
+	at91rs.cpunum = activecpu;
 	at91_build_priority_map();
 	return;
 }
 
 #if USE_MAME_TIMERS
 
-
+// Certain programs have problems with the deferred timer interrupts, while most others
+// work better. Expose a setting.
+int at91_block_timers = 0;
 
 static void timer_trigger_event(int timer_num)
-{
+{	
 	//reset counter and flag status
 	at91.tc_clock[timer_num].tc_counter = 0;
 	at91.tc_clock[timer_num].tc_status |= 0x10;
 
 	//generate an interrupt?
-
-	if(TC_RC_IRQ_ENABLED(timer_num))
+	if(TC_RC_IRQ_ENABLED(timer_num) /* &&  */) 
 	{
-		at91_fire_irq(AT91_TC0_IRQ+timer_num);
+		if (!at91_block_timers || (GET_CPSR & I_MASK) ==0)
+			at91_fire_irq(AT91_TC0_IRQ+timer_num);	
 	} 
 }
 #else

--- a/src/cpu/at91/at91.c
+++ b/src/cpu/at91/at91.c
@@ -46,6 +46,7 @@
 #include "../arm7/arm7core.h"
 #include "state.h"
 #include "mamedbg.h"
+#include <assert.h>
 
 //needed to capture this cpu's operating frequency
 extern int activecpu;
@@ -177,11 +178,13 @@ typedef struct
 	ARM7CORE_REGS								//these must be included in your cpu specific register implementation
 	int prev_cycles;							//# of previous cycles used since last opcode was performed.
 	int tot_prev_cycles;						//# of total previous cycles
-	int remap;									//flag if remap of ram occurred
-	int aic_vectors[32];						//holds vector address for each interrupt 0-31
+	int remap;	//flag if remap of ram occurred
+	data32_t aic_vectors[32];						//holds vector address for each interrupt 0-31
+	data32_t aic_smr[32];						//Holds IRQ priorities
 	data32_t aic_irqmask;						//holds the irq enabled mask for each interrupt 0-31 (0 = disabled, 1 = enabled) - 1 bit per interrupt.
 	data32_t aic_irqstatus;						//holds the status of the current interrupt # - 0-31 are valid #
 	data32_t aic_irqpending;					//holds the status of any pending interupts
+	data32_t aic_spurious;                      //Spurious interrupt vector
 	data32_t pio_enabled_status;				//holds status of each pio pin, 1 bit per pin. (0 = peripheral control, 1 = PIO control)
 	data32_t pio_output_status;					//holds output status of each pio pin, 1 bit per pin. (0 = Input Pin, 1 = Output Pin)
 	data32_t pio_output_data_status;			//holds output data status of each pio pin, 1 bit per pin. (0 = Pin Value is programmed as 0, 1 = Pin is programmed 1) - Only if pin is under PIO control and set as an output pin.
@@ -208,6 +211,7 @@ typedef struct
 static AT91_REGS at91;
 static AT91_REGS_RS at91rs;
 int at91_ICount;
+int at91_priority_map[31];
 
 #define AT91_RECEIVE_BUFFER_SIZE 512
 
@@ -388,6 +392,23 @@ char *GetUARTOffset(int addr)
 	else
 		sprintf(temp,"** Unknown **");
 	return temp;
+}
+
+void at91_build_priority_map()
+{
+	int i, c=0, j;
+
+	for(i=7;i>=0;i--)
+	{
+		for (j=1;j<32;j++)
+		{
+			if ((at91.aic_smr[j] & 0x07) == i)
+			{
+				at91_priority_map[c++]=j;
+			}
+		}
+	}
+	assert(c==31);
 }
 
 //Update the status of the pio pins (1 bit per pin)
@@ -1100,8 +1121,44 @@ INLINE void internal_write (int addr, data32_t data)
 			int offset2 = addr & 0x1ff;
 			switch(offset2)
 			{
-				//AIC Interrupt Vector Register - Based on current IRQ source 0-31, returns value of Source Vector
-				case 0x80:
+			case 0x00:
+				case 0x04:
+				case 0x08:
+				case 0x0c:
+				case 0x10:
+				case 0x14:
+				case 0x18:
+				case 0x1c:
+				case 0x20:
+				case 0x24:
+				case 0x28:
+				case 0x2c:
+				case 0x30:
+				case 0x34:
+				case 0x38:
+				case 0x3c:
+				case 0x40:
+				case 0x44:
+				case 0x48:
+				case 0x4c:
+				case 0x50:
+				case 0x54:
+				case 0x58:
+				case 0x5c:
+				case 0x60:
+				case 0x64:
+				case 0x68:
+				case 0x6c:
+				case 0x70:
+				case 0x74:
+				case 0x78:
+				case 0x7c:
+					at91.aic_smr[(addr-0xfffff000)/4] = data;
+					at91_build_priority_map();
+					break;
+									//AIC Interrupt Vector Register - Based on current IRQ source 0-31, returns value of Source Vector
+
+			case 0x80:
 				case 0x84:
 				case 0x88:
 				case 0x8c:
@@ -1160,6 +1217,9 @@ INLINE void internal_write (int addr, data32_t data)
 						arm7_core_set_irq_line(ARM7_IRQ_LINE, 1);
 						//arm7_core_set_irq_line(ARM7_IRQ_LINE, 0);
 					}
+					break;
+				case 0x134:
+					at91.aic_spurious = data ;
 					break;
 			}
 			if(logit) LOG(("%08x: AT91-AIC WRITE: %s (%08x) = %08x\n",activecpu_get_pc(),GetAICOffset(addr),addr,data));
@@ -1227,9 +1287,12 @@ INLINE data32_t internal_read (int addr)
 
 					//Counter Value
 					case 0x10:
-						data = at91.tc_clock[timer_num].tc_counter;
+					
 						#if USE_MAME_TIMERS
 						LOG(("Timer TC%d - Reading Counter Value not supported with MAME TIMERS!\n",timer_num));
+						data = at91.tc_clock[timer_num].tc_counter;// ARM7_ICOUNT;
+#else
+							data = at91.tc_clock[timer_num].tc_counter;
 						#endif
 
 						break;
@@ -1360,16 +1423,18 @@ INLINE data32_t internal_read (int addr)
 				case 0x100:  // IVR		
 					// Find the highest ranked vector that's set in irqpending
 				
-					for (i = 1; i < 32; i++)
+					for (i = 0; i < 31; i++)
 					{
-						if (at91.aic_irqpending & (1 << i))
+						if (at91.aic_irqpending & (1 << at91_priority_map[i]))
 						{
-							at91.aic_irqstatus = i;
-							data = at91.aic_vectors[i];
-							at91.aic_irqpending &= ~(1 << i);
+							at91.aic_irqstatus = at91_priority_map[i];
+							data = at91.aic_vectors[at91_priority_map[i]];
+							at91.aic_irqpending &= ~(1 << at91_priority_map[i]);
 							break;
 						}
 					}
+					if (i==31) 
+						data = at91.aic_spurious;
 					break;
 
 				//FIQ - Has it's own register address
@@ -1857,7 +1922,7 @@ void at91_init(void)
 
 	//Store the cpu clock frequency (is there any easier way to get this?)
 	at91rs.cpu_freq = Machine->drv->cpu[activecpu].cpu_clock;
-
+	at91_build_priority_map();
 	return;
 }
 

--- a/src/cpu/at91/at91.c
+++ b/src/cpu/at91/at91.c
@@ -92,11 +92,11 @@ INLINE void at91_cpu_write8( int addr, data8_t data );
 INLINE data32_t at91_cpu_read32( int addr );
 INLINE data16_t at91_cpu_read16( int addr );
 INLINE data8_t at91_cpu_read8( int addr );
-
-void (*at91_transmit_serial)(data8_t *data, int size) = NULL;
+void at91_fire_irq(int irqline);
+void (*at91_transmit_serial)(int usartno, data8_t *data, int size) = NULL;
 void sam_serial_hack();
 
-void at91_set_transmit_serial(void (*fp)(data8_t *data, int size))
+void at91_set_transmit_serial(void (*fp)(int usartno, data8_t *data, int size))
 {
 	at91_transmit_serial = fp;
 }
@@ -154,7 +154,7 @@ static void timer_trigger_event(int timer_num);
 #define TC_OVRFL_IRQ_ENABLED(x)		(at91.tc_clock[(x)].tc_irq_mask & 1)
 #define TC_WAVEMODE(x)				(at91.tc_clock[(x)].tc_chan_mode & 0x8000)		//bit 15 of Channel Mode = 1 for Wave Mode
 #define TC_RC_TRIGGER(x)			(at91.tc_clock[(x)].tc_chan_mode & 0x4000)		//bit 14 of Channel Mode = 1 for RC Compare Trigger
-
+#define AT91_USART_IRQ(x)           2+(1-x)
 /* Private Data */
 
 typedef struct
@@ -209,12 +209,38 @@ static AT91_REGS at91;
 static AT91_REGS_RS at91rs;
 int at91_ICount;
 
-// TODO: These belong in a struct, so they can be re-used for USART2 
-data32_t USART1_US_IMR = 0;
-data32_t USART1_US_CSR = 0x02;
-data32_t USART1_US_TPR = 0;
-data32_t USART1_US_TCR = 0;
-data32_t USART1_US_RPR = 0;
+#define AT91_RECEIVE_BUFFER_SIZE 512
+
+#define US_DMSI         (1<<10)
+#define US_TXEMPTY      (1<<9)
+#define US_TIMEOUT      (1<<8)
+#define US_PARE         (1<<7)
+#define US_FRAME        (1<<6)
+#define US_OVRE         (1<<5)
+#define US_ENDTX        (1<<4)
+#define US_ENDRX        (1<<3)
+#define US_RXBRK        (1<<2)
+#define US_TXRDY        (1<<1)
+#define US_RXRDY        (1)
+
+
+typedef struct 
+{ 	
+	data32_t US_IER; 
+	data32_t US_CSR;
+	data32_t US_TPR;
+	data32_t US_TCR;
+	data32_t US_RPR;
+	data32_t US_THR;
+	data32_t US_RCR;
+	int at91_rbuf_head;
+	int at91_rbuf_tail;
+
+	data8_t at91_receivebuf[AT91_RECEIVE_BUFFER_SIZE];
+
+} AT91_REGS_USART;
+
+static AT91_REGS_USART at91usart[2] = {{ 0, US_TXRDY | US_TXEMPTY | US_ENDTX,0,0,0,0,0,0 }, { 0, US_TXRDY | US_TXEMPTY | US_ENDTX,0,0,0,0,0,0 }};
 
 /* include the arm7 core */
 #include "../arm7/arm7core.c"
@@ -236,7 +262,7 @@ void DebuggerLog ( const char * format, ... )
   vsnprintf (buffer,256,format, args); 
   // Surely there's a more direct way lol
   swprintf(ws, 256, L"%hs", buffer); 
-//  OutputDebugStringW(ws);
+  OutputDebugStringW(ws);
   va_end (args);
 }
 
@@ -383,6 +409,227 @@ void update_pio_pins(int data)
 		at91.aic_irqpending |= 0x100;
 }
 
+mame_timer* at91_serial_timer=NULL;
+
+static void serial_timer_event(int timer_num);
+
+void at91_pending_serial(int usartno)
+{
+	// We can't process serial output immediately, the code will get confused and loop.
+	// So we set up a timer to process it a little bit later.
+	// I'm picking 60 * 60, because it needs to be able to write 
+	// 54 characters 60 times per second.  If this gets behind 
+	// things lag.   If this is too fast then it starts blocking
+	// timer interrupts
+	int freq = 60 * 60;  
+	timer_adjust(at91_serial_timer, TIME_IN_HZ(freq), 0, TIME_IN_HZ(freq));
+}
+
+static void serial_timer_event(int timer_num)
+{
+	int usartno, i;
+	timer_adjust(at91_serial_timer, TIME_NEVER, 0, TIME_NEVER);
+
+	for(usartno=0;usartno<2;usartno++)
+	{
+		if (at91usart[usartno].US_TCR > 0 && (at91usart[usartno].US_CSR & US_ENDTX) == 0 )
+		{
+#if (LOG_USART1_DATA_OUT && _DEBUG)
+			{
+				wchar_t tmp1[20];
+
+				OutputDebugStringW(L"DO: ");
+
+				for (i = 0; i < at91usart[usartno].US_TCR; i++)
+				{
+					data8_t b = cpu_readmem32ledw(at91usart[usartno].US_TPR + i);
+					swprintf(tmp1, _countof(tmp1), L"%02X", b);
+					OutputDebugStringW(tmp1);
+				}
+				OutputDebugStringW(L"\n");
+			}
+#endif 
+			if (at91_transmit_serial)
+			{
+				// TODO: There ought to be a way to get to the memory pointer and just pass it. 
+				// (memory_region?) 
+				
+				data8_t *pData = (data8_t *)malloc(sizeof(data8_t) * at91usart[usartno].US_TCR);
+				for (i = 0; i < at91usart[usartno].US_TCR; i++)
+				{
+					pData[i] = cpu_readmem32ledw(at91usart[usartno].US_TPR + i);
+				}
+				at91_transmit_serial(usartno, pData, at91usart[usartno].US_TCR);
+				free(pData);
+
+			}
+
+			// Move pointer forward
+			at91usart[usartno].US_TPR += at91usart[usartno].US_TCR;
+			// Clear counter
+			at91usart[usartno].US_TCR = 0x0;
+			// Channel status TX complete + TX Ready
+			at91usart[usartno].US_CSR |= US_TXRDY | US_TXEMPTY | US_ENDTX;
+			// if irq enbled fire.
+			if (at91usart[usartno].US_IER & (US_TXRDY | US_ENDTX))
+			{ 
+				at91_fire_irq(AT91_USART_IRQ(usartno));
+			}
+		} else if (at91usart[usartno].US_TPR == 0 && (at91usart[usartno].US_CSR & US_TXEMPTY) == 0 )
+			{
+#if (LOG_USART1_DATA_OUT && _DEBUG)
+				wchar_t tmp1[20];
+
+				if ((data8_t)at91usart[usartno].US_THR == 0x80)
+					OutputDebugStringW(L"\n");
+				swprintf(tmp1, _countof(tmp1), L"%02X", (data8_t)at91usart[usartno].US_THR);
+				OutputDebugStringW(tmp1);
+#endif			
+				if (at91_transmit_serial)
+				{
+					at91_transmit_serial(usartno, (data8_t*)&(at91usart[usartno].US_THR), 1);
+				}
+				// Channel status TX complete + TX Ready
+				at91usart[usartno].US_CSR |= US_TXRDY + US_TXEMPTY;
+
+				// Fire AIC IRQ for USART1.
+				if ((at91usart[usartno].US_IER & (US_TXEMPTY | US_TXRDY)) > 0)
+				{
+					at91_fire_irq(AT91_USART_IRQ(usartno));
+				} 
+			}
+	}
+}
+
+
+int at91_receive_serial(int usartno, data8_t *buf, int size)
+{
+	int remaining = size;
+
+	if (remaining==0)
+		return 0;
+
+	while(remaining)
+	{	
+		// Is buffer full? 
+		if ((at91usart[usartno].at91_rbuf_tail == 0 && at91usart[usartno].at91_rbuf_head == AT91_RECEIVE_BUFFER_SIZE-1) ||
+			(at91usart[usartno].at91_rbuf_tail-1  == at91usart[usartno].at91_rbuf_head))
+		{
+			break;
+		}
+		at91usart[usartno].at91_receivebuf[at91usart[usartno].at91_rbuf_head++] = *(buf++);
+		if (at91usart[usartno].at91_rbuf_head == AT91_RECEIVE_BUFFER_SIZE-1)
+			at91usart[usartno].at91_rbuf_head = 0;
+		remaining--;
+	}
+	// Let the ROM know there's something pending. 
+	// TODO: Implement PDC buffer mode, check if receive buffer configured 
+	// TODO: This should be moved into its own block of code too. 
+	if (!(at91usart[usartno].US_CSR & (US_RXRDY | US_ENDRX)))
+	{
+		at91usart[usartno].US_CSR |= (US_RXRDY | US_ENDRX);
+		at91_fire_irq(AT91_USART_IRQ(usartno));
+	}
+	return remaining;
+}
+
+
+void at91_usart_read(int usartno, int addr, data32_t *pData)
+{
+	switch ((addr & 0xff) / 4)
+	{
+	case 0x0c: // Receive pointer
+		if (usartno == 0)
+		{
+			static int hasrunhack =0;
+
+			if (!hasrunhack)
+			{
+				hasrunhack=1;
+				*pData = at91usart[usartno].US_RPR;
+				/* HACK ALERT - Not even going to bother doing this cleanly.  See funciton in sam.c for explanation. */
+				sam_serial_hack();
+				// Fire IRQ.
+				//this hack below gets some implementations to set up a receive buffer.
+				//at91usart[usartno].US_CSR |= US_ENDRX;
+				//at91.aic_irqstatus = AT91_USART_IRQ(usartno);
+				//at91_receive_serial(1,(data8_t *)"zc ver\r", 7);
+			}
+		}
+		*pData = at91usart[usartno].US_RPR;
+		break;
+	case 0x0d:  // Receive counter:
+		*pData = at91usart[usartno].US_RCR;
+		break;
+	case 0x0e:  // Transmit pointer
+		*pData = at91usart[usartno].US_TPR;
+		break;
+	case 0x0f:  // Transmit counter
+		*pData = at91usart[usartno].US_TCR;
+		break;
+	case 0x06:  // Receiver holding register 
+		*pData = at91usart[usartno].at91_receivebuf[at91usart[usartno].at91_rbuf_tail++];
+		if (at91usart[usartno].at91_rbuf_tail == AT91_RECEIVE_BUFFER_SIZE-1)
+			at91usart[usartno].at91_rbuf_tail = 0;
+		// No more characters left in buffer?  Clear rxready. 
+		if (at91usart[usartno].at91_rbuf_head == at91usart[usartno].at91_rbuf_tail) 
+			at91usart[usartno].US_CSR &= ~(US_RXRDY);
+		break;
+	case 0x05:  // Channel status 
+		*pData = at91usart[usartno].US_CSR;
+		break;
+	case 0x04: // Interrupt mask
+		*pData = at91usart[usartno].US_IER & at91usart[usartno].US_CSR;
+		break;
+	default:
+		break;
+	}
+	LOG(("%08x: AT91-USART%d READ: %s (%08x) = %08x\n", activecpu_get_pc(), usartno+1, GetUARTOffset(addr), addr, *pData));
+
+}
+
+
+void at91_usart_write(int usartno, int addr, data32_t outdata)
+{
+
+	LOG(("%08x: AT91-USART%d WRITE: %s (%08x) = %08x\n", activecpu_get_pc(), usartno+1, GetUARTOffset(addr), addr, outdata));
+	switch ((addr & 0xff) / 4)
+	{
+	case 0x02: // Interrupt Enable
+		// If we just enabled interrupts on something that would fire, we appear to need to fire here.
+		// Without this, the transmit loop never begins in some cases. 
+		if ((~at91usart[usartno].US_IER & outdata) & at91usart[usartno].US_CSR)
+		{
+			at91_fire_irq(AT91_USART_IRQ(usartno));
+		}
+		at91usart[usartno].US_IER |= outdata;
+		
+		break;
+	case 0x03:
+		at91usart[usartno].US_IER &= (~outdata);
+		break;
+	case 0x07:
+		at91usart[usartno].US_THR = outdata; // Transmit character
+		at91usart[usartno].US_CSR &= ~(US_TXRDY | US_TXEMPTY); 
+		at91_pending_serial(usartno);
+		break;
+	case 0x0c:
+		at91usart[usartno].US_RPR = outdata; // Receive pointer:
+		break;
+	case 0x0d:
+		at91usart[usartno].US_RCR = outdata; // Receive counter
+		at91usart[usartno].US_CSR &= ~(US_ENDRX); 
+		break;
+	case 0x0e:  // Transmit pointer
+		at91usart[usartno].US_TPR = outdata;
+		break;
+	case 0x0f:  // Transmit counter
+		at91usart[usartno].US_TCR = outdata;
+		at91usart[usartno].US_CSR &= ~(US_ENDTX); 
+		at91_pending_serial(usartno);
+		break;
+	}
+}
 
 //WRITE TO  - Atmel AT91 CPU On Chip Periperhals
 INLINE void internal_write (int addr, data32_t data)
@@ -508,75 +755,11 @@ INLINE void internal_write (int addr, data32_t data)
 
 		//USART1
 		case 0xcc:
-			LOG(("%08x: AT91-USART1 WRITE: %s (%08x) = %08x\n",activecpu_get_pc(),GetUARTOffset(addr),addr,data));
-			switch((addr & 0xff) / 4)
-			{
-			case 0x02: // Interrupt Enable
-				// Code has turned interrupts on which is to say
-				// it wants to be notified when transmission is complete. 
-				// So now's a good time to simulate that event if we have
-				// something to write.
-
-				if (USART1_US_TCR > 0 && (data & 0x10) == 0x10)
-				{
-					int i;
-
-#if (LOG_USART1_DATA_OUT && _DEBUG)
-					{
-						wchar_t tmp1[20];
-
-						OutputDebugStringW(L"DO: ");
-
-						for(i=0;i<USART1_US_TCR;i++)
-						{
-							data8_t b = cpu_readmem32ledw(USART1_US_TPR+i);
-							swprintf(tmp1, _countof(tmp1), L"%02X", b);
-							OutputDebugStringW(tmp1);
-						}
-						OutputDebugStringW(L"\n");
-					}
-#endif 
-					if (at91_transmit_serial)
-					{
-						// TODO: There ought to be a way to get to the memory pointer and just pass it. 
-
-						data8_t *pData = (data8_t *)malloc(sizeof(data8_t) * USART1_US_TCR);
-						for(i=0;i<USART1_US_TCR;i++)
-						{
-							pData[i] = cpu_readmem32ledw(USART1_US_TPR+i);
-						}
-						at91_transmit_serial(pData, USART1_US_TCR);
-						free(pData);
-					}
-					// Raise interrupt flag TX complete
-					USART1_US_IMR = 0x10;    
-					// Channel status TX complete + TX Ready
-					USART1_US_CSR = 0x12;
-					// Move pointer forward
-					USART1_US_TPR += USART1_US_TCR;
-					// Clear counter
-					USART1_US_TCR = 0x0;
-					// Fire AIC IRQ for USART1.
-					at91_set_irq_line(3, 1);
-				}			
-				break;
-			case 0x03:
-				USART1_US_IMR = 0x0;
-				break;
-			case 0x0c:
-				USART1_US_RPR = data; // Receive pointer:
-				break;
-				case 0x0e:  // Transmit pointer
-			    USART1_US_TPR = data;
-				break;
-		     	case 0x0f:  // Transmit counter
-				USART1_US_TCR = data;
-				break;
-			}			
+			at91_usart_write(0, addr, data);
 			break;
 		//USART2
 		case 0xd0:
-			LOG(("%08x: AT91-USART2 WRITE: %s (%08x) = %08x\n",activecpu_get_pc(),GetUARTOffset(addr),addr,data));
+			at91_usart_write(1, addr, data);
 			break;
 
 		//TC - Timer Counter
@@ -971,6 +1154,12 @@ INLINE void internal_write (int addr, data32_t data)
 				//End of Interrupt
 				case 0x130:
 					logit = LOG_AIC_EOI;
+					at91.aic_irqstatus = 0;
+					if (at91.aic_irqpending > 1)
+					{
+						arm7_core_set_irq_line(ARM7_IRQ_LINE, 1);
+						//arm7_core_set_irq_line(ARM7_IRQ_LINE, 0);
+					}
 					break;
 			}
 			if(logit) LOG(("%08x: AT91-AIC WRITE: %s (%08x) = %08x\n",activecpu_get_pc(),GetAICOffset(addr),addr,data));
@@ -982,9 +1171,11 @@ INLINE void internal_write (int addr, data32_t data)
 	}
 }
 
+
 //READ FROM  - Atmel AT91 CPU On Chip Periperhals
 INLINE data32_t internal_read (int addr)
 {
+	int i;
 	data32_t data = 0;
 	int offset2 = (addr & 0xFF000) >> 12;
 
@@ -1007,46 +1198,12 @@ INLINE data32_t internal_read (int addr)
 
 		//USART1
 		case 0xcc:
-			//LOG(("%08x: AT91-USART1 READ: %s (%08x) = %08x\n",activecpu_get_pc(),GetUARTOffset(addr),addr,data));
-		
-			switch((addr & 0xff) / 4)
-			{
-			case 0x0c: // Receive pointer
-				data = USART1_US_RPR;
-				/* HACK ALERT - Not even going to bother doing this cleanly.  See funciton in sam.c for explanation. */
-				sam_serial_hack();
-				LOG(("%08x: AT91-USART1 READ: %s (%08x) = %08x\n",activecpu_get_pc(),GetUARTOffset(addr),addr,data));
-				break;
-			case 0x0e:  // Transmit pointer
-				LOG(("%08x: AT91-USART1 READ: %s (%08x) = %08x\n",activecpu_get_pc(),GetUARTOffset(addr),addr,data));
-				data = USART1_US_TPR;
-				break;
-			case 0x0f:  // Transmit counter
-				LOG(("%08x: AT91-USART1 READ: %s (%08x) = %08x\n",activecpu_get_pc(),GetUARTOffset(addr),addr,data));
-				data = USART1_US_TCR;
-				break;
-			case 0x05:  // Channel status 
-				data = USART1_US_CSR;
-				LOG(("%08x: AT91-USART1 READ: %s (%08x) = %08x\n",activecpu_get_pc(),GetUARTOffset(addr),addr,data));
-			//	USART1_US_CSR|=0x02;
-				break;
-			case 0x04:
-				data = USART1_US_IMR;
-				LOG(("%08x: AT91-USART1 READ: %s (%08x) = %08x\n",activecpu_get_pc(),GetUARTOffset(addr),addr,data));
-			
-				//break;
-			default:
-				LOG(("%08x: AT91-USART1 READ: %s (%08x) = %08x\n",activecpu_get_pc(),GetUARTOffset(addr),addr,data));
-				break;
-			}
+			at91_usart_read(0, addr, &data);
 			break;
-	
-
 		//USART2
 		case 0xd0:
-			//LOG(("%08x: AT91-USART2 READ: %s (%08x) = %08x\n",activecpu_get_pc(),GetUARTOffset(addr),addr,data));
+			at91_usart_read(1, addr, &data);
 			break;
-
 		//TC - Timer Counter
 		case 0xe0:
 		{
@@ -1200,10 +1357,19 @@ INLINE data32_t internal_read (int addr)
 			switch(offset3)
 			{
 				//IRQ Based on current IRQ source 0-31, returns value of Source Vector
-				case 0x100:					
-					data = at91.aic_vectors[at91.aic_irqstatus];
-					// Clear irq status after address is read, so the "USART clobber check hack" works correctly.  
-					at91.aic_irqstatus = 0; 
+				case 0x100:  // IVR		
+					// Find the highest ranked vector that's set in irqpending
+				
+					for (i = 1; i < 32; i++)
+					{
+						if (at91.aic_irqpending & (1 << i))
+						{
+							at91.aic_irqstatus = i;
+							data = at91.aic_vectors[i];
+							at91.aic_irqpending &= ~(1 << i);
+							break;
+						}
+					}
 					break;
 
 				//FIQ - Has it's own register address
@@ -1236,6 +1402,9 @@ INLINE data32_t internal_read (int addr)
 	}
 	return data;
 }
+
+
+
 
 /***************************************************************************/
 
@@ -1377,7 +1546,7 @@ void at91_exit(void)
 		if(at91rs.timer[i])
 			timer_remove(at91rs.timer[i]);
 	}
-
+	timer_remove(at91_serial_timer);
 	//core cleanup
 	arm7_core_exit();
 }
@@ -1516,59 +1685,29 @@ void at91_set_nmi_line(int state)
 {
 }
 
-void at91_set_irq_line(int irqline, int state)
+
+void at91_fire_irq(int irqline)
 {
-	//todo - store pending?
-
-	//If attempting to set an Interrupt
-	if( state )
+	if ((at91.aic_irqmask & (1<<irqline)) == 0)
 	{
-		//Check if the IRQ Mask for current irq allows it.
-		if( (at91.aic_irqmask & (1<<irqline)) == 0)
-			return;
+		return;
 	}
 
-	//store current irq
-	
-	// HACK: COM interrupts are getting clobbered by timer interrupts. This is probably what is meant in by AIC improvements being needed.
-	// Don't allow IRQ status to be changed if it's a USART interrupt.  One USART IRQ loss is catastrophic,
-	// the TX event is never received, and no further output will occur. 
-	if (at91.aic_irqstatus != 3)
-		at91.aic_irqstatus = irqline;
-
-	//for debugging only - so I can put a breakpoint when an int is started (and avoid when it clears)
-	#ifdef MAME_DEBUG
-	if(state)
-	{
-		state = state;
-	}
-
-	//blocking checks - for testing only
-	#if INT_BLOCK_FIQ
-		if(irqline == AT91_FIQ_IRQ) return;
-	#endif
-	#if INT_BLOCK_IRQ0
-		if(irqline == AT91_IRQ0_IRQ) return;
-	#endif
-	#if INT_BLOCK_TC0
-		if(irqline == AT91_TC0_IRQ) return;
-	#endif
-	#if INT_BLOCK_TC1
-		if(irqline == AT91_TC1_IRQ) return;
-	#endif
-	#if INT_BLOCK_TC2
-		if(irqline == AT91_TC2_IRQ) return;
-	#endif
-
-	#endif		//MAME_DEBUG
-
-	//adjust our irq lines - ARM7 only has 2 external irq lines: IRQ & FIRQ
 	if(irqline == AT91_FIQ_IRQ)
 		irqline = ARM7_FIRQ_LINE;		//if it's our FIQ, make it ARM7 FIRQ
 	else
+	{
+		at91.aic_irqpending |= (1 << irqline);
 		irqline = ARM7_IRQ_LINE;		//Anything else is an ARM7 IRQ.
+	}
 
-	//must call core
+	arm7_core_set_irq_line(irqline, 1);
+//	arm7_core_set_irq_line(irqline, 0);  // Doesn't seem to be needed?
+}
+
+void at91_set_irq_line(int irqline, int state)
+{
+	
 	arm7_core_set_irq_line(irqline,state);
 }
 
@@ -1714,6 +1853,7 @@ void at91_init(void)
 	{
 		at91rs.timer[i] = timer_alloc(timer_trigger_event);
 	}
+	at91_serial_timer = timer_alloc(serial_timer_event);
 
 	//Store the cpu clock frequency (is there any easier way to get this?)
 	at91rs.cpu_freq = Machine->drv->cpu[activecpu].cpu_clock;
@@ -1722,6 +1862,9 @@ void at91_init(void)
 }
 
 #if USE_MAME_TIMERS
+
+
+
 static void timer_trigger_event(int timer_num)
 {
 	//reset counter and flag status
@@ -1729,10 +1872,11 @@ static void timer_trigger_event(int timer_num)
 	at91.tc_clock[timer_num].tc_status |= 0x10;
 
 	//generate an interrupt?
+
 	if(TC_RC_IRQ_ENABLED(timer_num))
 	{
-		at91_set_irq_line(AT91_TC0_IRQ+timer_num,1);
-	}
+		at91_fire_irq(AT91_TC0_IRQ+timer_num);
+	} 
 }
 #else
 INLINE BeforeOpCodeHook(void)

--- a/src/cpu/at91/at91.h
+++ b/src/cpu/at91/at91.h
@@ -90,6 +90,8 @@ extern void at91_init_jit(int min_addr, int max_addr);
 extern void at91_cs_callback_r(offs_t start, offs_t end, READ32_HANDLER((*callback)));
 extern void at91_cs_callback_w(offs_t start, offs_t end, WRITE32_HANDLER((*callback)));
 extern void at91_ready_irq_callback_w(WRITE32_HANDLER((*callback)));
-extern void at91_set_transmit_serial(void (*fp)(data8_t *data, int size));
+extern void at91_set_transmit_serial(void (*fp)(int usartno, data8_t *data, int size));
 
 #endif /* AT91_H */
+
+void at91_usart_read(int usartno, int addr, data32_t *pData);

--- a/src/cpu/at91/at91.h
+++ b/src/cpu/at91/at91.h
@@ -90,5 +90,6 @@ extern void at91_init_jit(int min_addr, int max_addr);
 extern void at91_cs_callback_r(offs_t start, offs_t end, READ32_HANDLER((*callback)));
 extern void at91_cs_callback_w(offs_t start, offs_t end, WRITE32_HANDLER((*callback)));
 extern void at91_ready_irq_callback_w(WRITE32_HANDLER((*callback)));
+extern void at91_set_transmit_serial(void (*fp)(data8_t *data, int size));
 
 #endif /* AT91_H */

--- a/src/mame.h
+++ b/src/mame.h
@@ -233,6 +233,8 @@ struct GameOptions
 	int		debug_height;	/* requested height of debugger bitmap */
 	int		debug_depth;	/* requested depth of debugger bitmap */
 
+	int		at91jit;
+
 	#ifdef MESS
 	UINT32 ram;
 	struct ImageFile image_files[MAX_IMAGES];

--- a/src/mamedbg.c
+++ b/src/mamedbg.c
@@ -1789,6 +1789,7 @@ static void trace_output( void )
 			activecpu_dasm( dst, pc );
 			strcat( dst, "\n" );
 			fprintf( TRACE.file, "%s", buffer );
+			fflush(TRACE.file);
 			memmove(
 				&TRACE.last_pc[0],
 				&TRACE.last_pc[1],

--- a/src/mamedbg.c
+++ b/src/mamedbg.c
@@ -1617,7 +1617,7 @@ static unsigned get_register_id( char **parg, int *size )
 	for( i = 0; i < DBGREGS.count; i++ )
 	{
 		l = strlen( DBGREGS.name[i] );
-		if( l > 0 && !strncasecmp( *parg, DBGREGS.name[i], l ) )
+		if( l > 0 && !strnicmp( *parg, DBGREGS.name[i], l ) )
 		{
 			if( !isalnum( (*parg)[l] ) )
 			{

--- a/src/win32com/Controller.cpp
+++ b/src/win32com/Controller.cpp
@@ -869,7 +869,7 @@ STDMETHODIMP CController::get_ChangedLampsState(int **buf, int *pVal)
   for (int i = 0; i < uCount; i++)
   {
     *(dst++) = chgLamps[i].lampNo;
-    *(dst++) = chgLamps[i].currStat ? 1:0;
+    *(dst++) = chgLamps[i].currStat;
   }
 
   *pVal = uCount;
@@ -1274,7 +1274,7 @@ STDMETHODIMP CController::get_ChangedLamps(VARIANT *pVal)
     varValue.lVal = chgLamps[ix[0]].lampNo;
     SafeArrayPutElement(psa, ix, &varValue);
     ix[1] = 1; // Lamp value
-    varValue.lVal = chgLamps[ix[0]].currStat?1:0;
+    varValue.lVal = chgLamps[ix[0]].currStat;
     SafeArrayPutElement(psa, ix, &varValue);
   }
 

--- a/src/windows/config.c
+++ b/src/windows/config.c
@@ -271,6 +271,7 @@ struct rc_option core_opts[] = {
         { "skip_gameinfo", NULL, rc_bool, &options.skip_gameinfo, "0", 0, 0, NULL, "skip displaying the game info screen" },
         { "crconly", NULL, rc_bool, &options.crc_only, "0", 0, 0, NULL, "use only CRC for all integrity checks" },
         { "bios", NULL, rc_string, &options.bios, "default", 0, 14, NULL, "change system bios" },
+		{ "at91jit", NULL, rc_int, &options.at91jit, "1", 0, 33554432, NULL, "at91 CPU JIT compiler enabled" }, 
 
         /* config options */
         { "Configuration options", NULL, rc_seperator, NULL, NULL, 0, 0, NULL, NULL },

--- a/src/windows/jit.c
+++ b/src/windows/jit.c
@@ -66,6 +66,7 @@ struct jit_ctl *_jit_create(int *cycle_counter, int rshift)
 	jit->native = 0;
 	jit->rshift = rshift;
 	jit->pages = 0;
+	jit->mem_count = 0;
 	jit->cycle_counter_ptr = cycle_counter;
 
 	// initialize the native code page list
@@ -104,7 +105,7 @@ static void init_code_pages(struct jit_ctl *jit)
 	
 	// allocate the first page for native code storage (use the default length)
 	jit_add_page(jit, 0);
-
+	
 	// reserve space for the boilerplate code
 	p = res = jit_reserve_native(jit, reslen = 16, 0);
 
@@ -330,6 +331,7 @@ static void delete_code_pages(struct jit_ctl *jit)
 	jit->pPending = 0;
 	jit->pWorking = 0;
 	jit->pLookup = 0;
+	jit->mem_count = 0;
 }
 
 void jit_create_map(struct jit_ctl *jit, data32_t minAddr, data32_t maxAddr)
@@ -400,6 +402,9 @@ void jit_untranslate(struct jit_ctl *jit, data32_t addr)
 
 	// if it's not in the JIT covered memory space, there's nothing to do
 	if (addr < jit->minAddr || addr >= jit->maxAddr)
+		return;
+
+	if (addr >= 0x97f0 || addr <= 0x98ff)
 		return;
 
 	// un-translate only if the existing opcode is translated
@@ -500,6 +505,22 @@ byte *jit_store_native(struct jit_ctl *jit, const byte *code, int len)
 	return dst;
 }
 
+void jit_store_native_from_reserved(struct jit_ctl *jit, const byte *code, int len, struct jit_page *pg, const byte *dst)
+{
+	// copy the data, if any
+	if (len != 0)
+	{
+		// store the instruction data
+		memcpy(dst, code, len);
+
+		// consume the space
+		pg->ofsFree += len;
+		
+		// flush the CPU instruction cache for the area where the new code resides
+		FlushInstructionCache(GetCurrentProcess(), dst, len);
+	}
+}
+
 static struct jit_page *jit_add_page(struct jit_ctl *jit, int min_siz)
 {
 	DWORD prvPro;
@@ -530,6 +551,7 @@ static struct jit_page *jit_add_page(struct jit_ctl *jit, int min_siz)
 	VirtualProtect(p->b, siz, BASE_CODEPAGE_MODE, &prvPro);
 
 	// return the new page pointer
+	jit->mem_count+=siz;
 	return p;
 }
 

--- a/src/windows/jit.h
+++ b/src/windows/jit.h
@@ -395,6 +395,7 @@ struct jit_ctl
 	// for this CPU.  The JIT uses this internally to manage the memory
 	// containing the translated code.
 	struct jit_page *pages;
+	data32_t mem_count;
 
 	// Read and write callbacks.  The generated code calls these
 	// functions to access memory.
@@ -729,6 +730,11 @@ byte *jit_reserve_native(struct jit_ctl *jit, int len, /*OUT*/ struct jit_page *
  *   page.  Returns the address of the stored code.
  */
 byte *jit_store_native(struct jit_ctl *jit, const byte *code, int len);
+
+/* Same as jit_store_native but does not try to find a new location for code. Needed for blocks of code with relative jumps */
+
+void jit_store_native_from_reserved(struct jit_ctl *jit, const byte *code, int len, struct jit_page *pg, const byte *dst);
+
 
 /*
  *   End a store-native operation.  Each call to jit_reserve_native() should

--- a/src/windows/jitemit.c
+++ b/src/windows/jitemit.c
@@ -78,7 +78,6 @@
 #include <string.h>
 #include <assert.h>
 #include <stdint.h>
-#include <windows.h>
 
 #include "memory.h"
 #include "jit.h"
@@ -723,13 +722,7 @@ void jit_emit_commit(struct jit_ctl *jit)
 
 				// get the label address
 			    byte *lblnat = label_to_native(jit, i->lbl);
-				
-				//int lbldelta = lblnat - (i->nataddr + i->len);
-				INT64 lbldelta = (INT64)lblnat - ((INT64)i->nataddr + (INT64)i->len);
-				assert(lbldelta >= INT32_MIN && lbldelta <= INT32_MAX);
-				if(!(lbldelta >= INT32_MIN && lbldelta <= INT32_MAX))
-					MessageBoxW(NULL, L"Jump span overflow", L"Code is too far away", MB_OK);
-
+				int lbldelta = lblnat - (i->nataddr + i->len);
 
 				// If it's one of the special emulator handlers, it will definitely be
 				// out of range of a one-byte jump.  Further, we must use a proxy jump,
@@ -935,12 +928,7 @@ void jit_emit_commit(struct jit_ctl *jit)
 			// get the native code address of the label target, and
 			// calculate the offset from the end of this instruction
 			byte *lblnat = label_to_native(jit, i->lbl);
-//			int lbldelta = lblnat - (i->nataddr + i->len);
-			INT64 lbldelta = (INT64)lblnat - ((INT64)i->nataddr + (INT64)i->len);
-			assert(lbldelta >= INT32_MIN && lbldelta <= INT32_MAX);
-			// Temporary checking toxies problem
-			if(!(lbldelta >= INT32_MIN && lbldelta <= INT32_MAX))
-				MessageBoxW(NULL, L"Jump span overflow", L"Code is too far away", MB_OK);
+			int lbldelta = lblnat - (i->nataddr + i->len);
 
 			// There can be no unresolved labels remaining at this point.
 			// Anything that was pointing to non-translated code must have

--- a/src/windows/jitemit.c
+++ b/src/windows/jitemit.c
@@ -78,6 +78,7 @@
 #include <string.h>
 #include <assert.h>
 #include <stdint.h>
+#include <windows.h>
 
 #include "memory.h"
 #include "jit.h"
@@ -722,7 +723,13 @@ void jit_emit_commit(struct jit_ctl *jit)
 
 				// get the label address
 			    byte *lblnat = label_to_native(jit, i->lbl);
-				int lbldelta = lblnat - (i->nataddr + i->len);
+				
+				//int lbldelta = lblnat - (i->nataddr + i->len);
+				INT64 lbldelta = (INT64)lblnat - ((INT64)i->nataddr + (INT64)i->len);
+				assert(lbldelta >= INT32_MIN && lbldelta <= INT32_MAX);
+				if(!(lbldelta >= INT32_MIN && lbldelta <= INT32_MAX))
+					MessageBoxW(NULL, L"Jump span overflow", L"Code is too far away", MB_OK);
+
 
 				// If it's one of the special emulator handlers, it will definitely be
 				// out of range of a one-byte jump.  Further, we must use a proxy jump,
@@ -928,7 +935,12 @@ void jit_emit_commit(struct jit_ctl *jit)
 			// get the native code address of the label target, and
 			// calculate the offset from the end of this instruction
 			byte *lblnat = label_to_native(jit, i->lbl);
-			int lbldelta = lblnat - (i->nataddr + i->len);
+//			int lbldelta = lblnat - (i->nataddr + i->len);
+			INT64 lbldelta = (INT64)lblnat - ((INT64)i->nataddr + (INT64)i->len);
+			assert(lbldelta >= INT32_MIN && lbldelta <= INT32_MAX);
+			// Temporary checking toxies problem
+			if(!(lbldelta >= INT32_MIN && lbldelta <= INT32_MAX))
+				MessageBoxW(NULL, L"Jump span overflow", L"Code is too far away", MB_OK);
 
 			// There can be no unresolved labels remaining at this point.
 			// Anything that was pointing to non-translated code must have

--- a/src/windows/jitemit.c
+++ b/src/windows/jitemit.c
@@ -77,6 +77,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>
+#include <stdint.h>
 
 #include "memory.h"
 #include "jit.h"
@@ -598,6 +599,8 @@ void jit_emit_commit(struct jit_ctl *jit)
 	byte *resp;
 	struct instr *i;
 	byte *p;
+	struct jit_page *pg;
+
 
 	// if there's no code, there's nothing to do
 	if (stktop->ihead == 0)
@@ -650,7 +653,7 @@ void jit_emit_commit(struct jit_ctl *jit)
 	len += 1;
 
 	// Reserve the space
-	resp = jit_reserve_native(jit, reslen = len, 0);
+	resp = jit_reserve_native(jit, reslen = len, &pg);  
 
 	// Edit jumps that exceed +/- 127 bytes.  On each pass, we'll
 	// look for any two-byte jumps that are out of bounds.  For
@@ -963,14 +966,13 @@ void jit_emit_commit(struct jit_ctl *jit)
 		}
 		
 		// copy this instruction to the JIT executable code page
-		p = jit_store_native(jit, i->b, i->len);
-		ASSERT(p == i->nataddr);
+		jit_store_native_from_reserved(jit, i->b, i->len, pg, i->nataddr);
 
 		// if this is the first native instruction for this emulated opcode,
 		// set the address mapping
 		if (i->emuaddr != emuaddr) {
 			emuaddr = i->emuaddr;
-			JIT_NATIVE(jit, emuaddr) = p;
+			JIT_NATIVE(jit, emuaddr) = i->nataddr;
 		}
 	}
 

--- a/src/wpc/core.h
+++ b/src/wpc/core.h
@@ -300,6 +300,7 @@ extern void video_update_core_dmd(struct mame_bitmap *bitmap, const struct recta
 #define CORE_CUSTSWCOL     CORE_STDSWCOLS  /* first custom (game specific) switch column */
 #define CORE_MAXLAMPCOL     42   /* lamp column (0-7=std lamp matrix 8- custom) */
 #define CORE_CUSTLAMPCOL   CORE_STDLAMPCOLS  /* first custom lamp column */
+#define CORE_MAXRGBLAMPS     260      //!! ??
 #define CORE_MAXPORTS        8   /* Maximum input ports */
 #define CORE_MAXGI           5   /* Maximum GI strings */
 #define CORE_MAXNVRAM        131118 /* Maximum number of NVRAM bytes, only used for get_ChangedNVRAM so far */
@@ -382,6 +383,7 @@ typedef struct {
   UINT8  swMatrix[CORE_MAXSWCOL];
   UINT8  invSw[CORE_MAXSWCOL];   /* Active low switches */
   UINT8  lampMatrix[CORE_MAXLAMPCOL], tmpLampMatrix[CORE_MAXLAMPCOL];
+  UINT8  RGBlamps[CORE_MAXRGBLAMPS];
   core_tSeg segments;     /* segments data from driver */
   UINT16 drawSeg[CORE_SEGCOUNT]; /* segments drawn */
   UINT32 solenoids;       /* on power driver bord */

--- a/src/wpc/desound.c
+++ b/src/wpc/desound.c
@@ -659,7 +659,10 @@ static void remove_led_code(void)
 static void setup_at91(void)
 {
   //set up the JIT memory map - allow for 128k of address space from address 0
-  at91_init_jit(0, 0x20000);
+  if (options.at91jit)
+  {
+	 at91_init_jit(0, 0x20000);
+  }
   //because the boot rom code gets written to ram, and then remapped to page 0, we need an interface to handle this.
   at91_set_ram_pointers(de3as_reset_ram,de3as_page0_ram);
   //Copy U7 ROM into correct location (ie, starting at 0x40000000 where it is mapped)

--- a/src/wpc/vpintf.c
+++ b/src/wpc/vpintf.c
@@ -6,6 +6,7 @@
 
 static struct {
   UINT8  lastLampMatrix[CORE_MAXLAMPCOL];
+  UINT32 lastRGBLamps[CORE_MAXRGBLAMPS];
   UINT64 lastSol;
   UINT32 solMask[2];
   int    lastGI[CORE_MAXGI];
@@ -38,11 +39,13 @@ int vp_getLamp(int lampNo) {
 /-------------------------------------*/
 int vp_getChangedLamps(vp_tChgLamps chgStat) {
   UINT8 lampMatrix[CORE_MAXLAMPCOL];
+  UINT32 RGBlamps[CORE_MAXRGBLAMPS];
   int idx = 0;
   int ii;
 
   /*-- get current status --*/
   memcpy(lampMatrix, coreGlobals.lampMatrix, sizeof(lampMatrix));
+  memcpy(RGBlamps, coreGlobals.RGBlamps, sizeof(RGBlamps));
 
   /*-- fill in array --*/
   for (ii = 0; ii < CORE_STDLAMPCOLS+core_gameData->hw.lampCol; ii++) {
@@ -62,7 +65,18 @@ int vp_getChangedLamps(vp_tChgLamps chgStat) {
       }
     }
   }
+
+  for (ii = 0; ii < CORE_MAXRGBLAMPS; ii++) {
+	  int chgLamp = RGBlamps[ii] ^ locals.lastRGBLamps[ii];
+	  if (chgLamp) {
+		  chgStat[idx].lampNo = ii+80; //!!
+		  chgStat[idx].currStat = RGBlamps[ii]; //!! remap?
+		  idx += 1;
+	  }
+  }
+
   memcpy(locals.lastLampMatrix, lampMatrix, sizeof(lampMatrix));
+  memcpy(locals.lastRGBLamps, RGBlamps, sizeof(RGBlamps));
   return idx;
 }
 

--- a/src/wpc/vpintf.c
+++ b/src/wpc/vpintf.c
@@ -6,7 +6,7 @@
 
 static struct {
   UINT8  lastLampMatrix[CORE_MAXLAMPCOL];
-  UINT32 lastRGBLamps[CORE_MAXRGBLAMPS];
+  UINT8 lastRGBLamps[CORE_MAXRGBLAMPS];
   UINT64 lastSol;
   UINT32 solMask[2];
   int    lastGI[CORE_MAXGI];
@@ -39,7 +39,7 @@ int vp_getLamp(int lampNo) {
 /-------------------------------------*/
 int vp_getChangedLamps(vp_tChgLamps chgStat) {
   UINT8 lampMatrix[CORE_MAXLAMPCOL];
-  UINT32 RGBlamps[CORE_MAXRGBLAMPS];
+  UINT8 RGBlamps[CORE_MAXRGBLAMPS];
   int idx = 0;
   int ii;
 
@@ -69,8 +69,11 @@ int vp_getChangedLamps(vp_tChgLamps chgStat) {
   for (ii = 0; ii < CORE_MAXRGBLAMPS; ii++) {
 	  int chgLamp = RGBlamps[ii] ^ locals.lastRGBLamps[ii];
 	  if (chgLamp) {
-		  chgStat[idx].lampNo = ii+80; //!!
-		  chgStat[idx].currStat = RGBlamps[ii]; //!! remap?
+		  // With this mapping 1-80 are "legacy" 
+		  // 8 bit lamps, and 81+ are modern intensity-level
+		  // RGB capable LEDs.  
+		  chgStat[idx].lampNo = ii+81;  
+		  chgStat[idx].currStat = RGBlamps[ii]; 
 		  idx += 1;
 	  }
   }


### PR DESCRIPTION
Final list of new features:

1) Enable JIT compiling for faster performance, with registry option to disable. 
2) More fully implemented IRQ controller, improves sluggishness in a lot of games like Family Guy, and allows accurate timing selection.
4) LE 8 and 12 solenoid aux board support for all LE games (X-men, Metallica, ACDC, etc..) 
5) RGB 256-level LED string implementations for Star Trek LE, Mustang Pro and LE (1.45 only, other roms may work but with delay), AC/DC LE, Metallica LE,  The Walking Dead LE
3) Serial port implementation available for future ColorDMD expansion.

Known issues:

1) The more accurate timing breaks CSI / IJ.   It's not apparent to me why.    Would love to understand what it takes to make it work correctly.   Workaround is in place. 

2) Mustang is waiting for some specific response from the LED controller board that I don't know, and what that is isn't obvious looking at code.   Hacking works fine but is ROM version specific.

3) There are two buggy JIT instructions that are not fixed.   The impact of this is pretty negligible, I've coded them to return to normal emulation.  They're not commonly used to so there's not much impact. 
